### PR TITLE
fix go-homedir commit number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor/
 letsencrypt.cache
 tmp/
 node_modules
+.idea*
+*.iml

--- a/glide.lock
+++ b/glide.lock
@@ -117,7 +117,7 @@ imports:
 - name: github.com/mattn/go-isatty
   version: a5cdd64afdee435007ee3e9f6ed4684af949d568
 - name: github.com/minio/go-homedir
-  version: 21304a94172ae3a09dee2cd86a12fb6f842138c7
+  version: 4d76aabb80b22bad8695d3904e943f1fb5e6199f
 - name: github.com/minio/minio-go
   version: 4e0f567303d4cc90ceb055a451959fb9fc391fb9
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,6 +29,7 @@ import:
 - package: github.com/go-ini/ini
   version: ~1.30.3
 - package: github.com/minio/go-homedir
+  version: 4d76aabb80b22bad8695d3904e943f1fb5e6199f
 - package: github.com/hashicorp/nomad
   version: ~0.7.0
   subpackages:


### PR DESCRIPTION
glide install would continue to fail with the older commit number.